### PR TITLE
Add PriceResolver contract

### DIFF
--- a/contractV2/contracts/PriceResolver.sol
+++ b/contractV2/contracts/PriceResolver.sol
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.6.12;
+
+import "./utility/Lockable.sol";
+import "./utility/Whitelist.sol";
+import "./interfaces/IPriceResolver.sol";
+import "./interfaces/IChainlinkPriceFeeder.sol";
+import "./utility/LibMath.sol";
+
+/**
+ * @title A contract to resolves the asset price
+ */
+
+contract PriceResolver is Lockable, Whitelist, IPriceResolver {
+
+    using LibMathSigned for int256;
+    using LibMathUnsigned for uint256;
+
+    // Price feeder contract.
+    IChainlinkPriceFeeder public priceFeeder;
+    // Price feeder contract of collateral asset
+    IChainlinkPriceFeeder public priceFeederCollateral;
+
+    // fall-back value from avg price
+    uint256 public emergencyAvgPrice;
+
+    constructor(
+        address _priceFeederAddress,
+        address _priceFeederCollateralAddress,
+        uint256 _emergencyAvgPrice,
+        address _devAddress
+    ) public nonReentrant() {
+        require( _priceFeederAddress != address(0), "Invalid _priceFeederAddress" );
+        require( _priceFeederCollateralAddress != address(0), "Invalid _priceFeederCollateralAddress" );
+        require( _emergencyAvgPrice != 0, "Reference price can't be zero" );
+
+        priceFeeder = IChainlinkPriceFeeder(_priceFeederAddress);
+        priceFeederCollateral = IChainlinkPriceFeeder(_priceFeederCollateralAddress);
+
+        emergencyAvgPrice = _emergencyAvgPrice;
+
+        addAddress(_devAddress);
+        
+        if (_devAddress != msg.sender) {
+            addAddress(msg.sender);
+        }
+    }
+
+    // update the fall-back avg price
+    function setEmergencyPrice(uint256 _value) public nonReentrant() onlyWhitelisted() {
+        emergencyAvgPrice = _value;
+    }
+
+    // get the fall-back avg price
+    function getEmergencyReferencePrice() public view returns (uint256) {
+        return emergencyAvgPrice;
+    }
+
+    // get the current price
+    function getCurrentPrice() override external view returns (uint256) {
+        return priceFeeder.getValue();
+    }
+
+    // get the current price of the collateral
+    function getCurrentPriceCollateral() override external view returns (uint256) {
+        return priceFeederCollateral.getValue();
+    }
+
+    // get avg 30d price of the collateral
+    function getAvg30Price() override external view returns (uint256) {
+        return _getAvgPrice(30);
+    }
+
+    // get avg 60d price of the collateral
+    function getAvg60Price() override external view returns (uint256) {
+        return _getAvgPrice(60);
+    }
+
+    // get raw mint ratio
+    function getRawRatio() override external view returns (uint256) {
+        return _rawRatio();
+    }
+
+    // get adjusted mint ratio
+    function getCurrentRatio() override external view returns (uint256) {
+        return _adjustedRatio();
+    }
+
+    // the flag to identify the market
+    function isBullMarket() override public view returns (bool) {
+        uint256 ratio = _rawRatio();
+        if (ratio > 500000000000000000) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    // INTERNAL FUNCTIONS
+
+    // get a collateral asset avg price of totalDay
+    function _getAvgPrice(uint8 totalDay) internal view returns (uint256) {
+        try priceFeederCollateral.getAveragePrice( totalDay ) returns (
+            uint256 value,
+            uint8 count
+        ) {
+            
+            return value;
+        } catch Error(
+            string memory /*reason*/
+        ) {
+            return emergencyAvgPrice;
+        } catch (
+            bytes memory /*lowLevelData*/
+        ) {
+            return emergencyAvgPrice;
+        }
+    }
+
+    // ratio = latest price / (avg 30d price + avg 60d price) , >0.5  = bull , <0.5 = bear
+    function _rawRatio() internal view returns (uint256) {
+        return ((priceFeederCollateral.getValue()).wdiv( _getAvgPrice(30).add(_getAvgPrice(60))));
+    }
+
+    // capping the ratio between 0.2 and 0.8
+    function _adjustedRatio() internal view returns (uint256) {
+        uint256 ratio = _rawRatio();
+        if (ratio > 800000000000000000) { // 0.8
+            ratio = 800000000000000000;
+        } else if (ratio < 200000000000000000) { // 0.2
+            ratio = 200000000000000000;
+        }
+        return ratio;
+    }
+
+}

--- a/contractV2/contracts/Reward.sol
+++ b/contractV2/contracts/Reward.sol
@@ -6,11 +6,11 @@ import '@openzeppelin/contracts/math/SafeMath.sol';
 import '@openzeppelin/contracts/token/ERC20/IERC20.sol';
 import '@openzeppelin/contracts/token/ERC20/SafeERC20.sol';
 import '@openzeppelin/contracts/access/Ownable.sol';
-import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+import "./utility/Lockable.sol";
             
 import "./interfaces/IMasterChef.sol";
 
-contract Reward is Ownable, ReentrancyGuard {
+contract Reward is Ownable, Lockable {
     using SafeMath for uint256;
     using SafeERC20 for IERC20;
 

--- a/contractV2/contracts/TokenFactory.sol
+++ b/contractV2/contracts/TokenFactory.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.6.12;
+
+import "./utility/SyntheticToken.sol";
+import "./interfaces/IExpandedIERC20.sol";
+import "./utility/Lockable.sol";
+
+
+/**
+ * @title Factory for creating new mintable and burnable tokens.
+ */
+
+contract TokenFactory is Lockable {
+
+    event TokenCreated(address indexed tokenAddress);
+
+    /**
+     * @notice Create a new token and return it to the caller.
+     * @dev The caller will become the only minter and burner and the new owner capable of assigning the roles.
+     * @param tokenName used to describe the new token.
+     * @param tokenSymbol short ticker abbreviation of the name. Ideally < 5 chars.
+     * @param tokenDecimals used to define the precision used in the token's numerical representation.
+     * @return newToken an instance of the newly created token interface.
+     */
+    function createToken(
+        string calldata tokenName,
+        string calldata tokenSymbol,
+        uint8 tokenDecimals
+    ) external nonReentrant() returns (IExpandedIERC20 newToken) {
+        SyntheticToken mintableToken = new SyntheticToken(tokenName, tokenSymbol, tokenDecimals);
+        mintableToken.addMinter(msg.sender);
+        mintableToken.addBurner(msg.sender);
+        mintableToken.resetOwner(msg.sender);
+        newToken = IExpandedIERC20(address(mintableToken));
+
+        emit TokenCreated(address(newToken));
+
+    }
+
+}

--- a/contractV2/contracts/interfaces/IPriceResolver.sol
+++ b/contractV2/contracts/interfaces/IPriceResolver.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.6.12;
+
+interface IPriceResolver {
+
+    function getCurrentPrice() external view returns (uint256);
+
+    function getCurrentPriceCollateral() external view returns (uint256);
+
+    function getCurrentRatio() external view returns (uint256);
+
+    function getRawRatio() external view returns (uint256);
+
+    function getAvg30Price() external view returns (uint256);
+
+    function getAvg60Price() external view returns (uint256);
+
+    function isBullMarket() external view returns (bool);
+
+}

--- a/contractV2/test/PriceResolver.js
+++ b/contractV2/test/PriceResolver.js
@@ -1,0 +1,89 @@
+const { expect } = require("chai");
+const { fromEther, toEther } = require("./Helpers")
+
+let priceResolver
+let priceFeeder
+let priceFeederCollateral
+let admin
+let alice
+
+describe("PriceResolver contract", () => {
+
+    before(async () => {
+
+        [admin, alice] = await ethers.getSigners();
+
+        const MockPriceFeeder = await ethers.getContractFactory("MockPriceFeeder");
+        priceFeeder = await MockPriceFeeder.deploy("ETH/USD");
+
+        priceFeederCollateral = await MockPriceFeeder.deploy("BNB/USD");
+
+        // update value
+        await priceFeeder.connect(admin).updateValue(toEther(2500));
+        await priceFeederCollateral.connect(admin).updateValue(toEther(20));
+        await priceFeederCollateral.connect(admin).setAveragePrice(toEther(20));
+
+        // setup price resolver contract
+        const PriceResolver = await ethers.getContractFactory("PriceResolver")
+        priceResolver = await PriceResolver.deploy(
+            priceFeeder.address,
+            priceFeederCollateral.address,
+            toEther(20),
+            admin.address
+        );
+
+    });
+
+    it('all initial value are correct', async () => {
+
+        expect(fromEther(await priceResolver.getEmergencyReferencePrice())).to.equal("20.0")
+        expect((await priceResolver.priceFeeder())).to.equal(priceFeeder.address)
+        expect((await priceResolver.priceFeederCollateral())).to.equal(priceFeederCollateral.address)
+
+    })
+
+    it('both price feeder contracts return correct value', async () => {
+
+        const assetPrice = await priceFeeder.getValue()
+        const collateralPrice = await priceFeederCollateral.getValue()
+
+        expect(fromEther(assetPrice)).to.equal("2500.0")
+        expect(fromEther(collateralPrice)).to.equal("20.0")
+
+        expect(await priceResolver.getCurrentPrice()).to.equal(assetPrice)
+        expect(await priceResolver.getCurrentPriceCollateral()).to.equal(collateralPrice)
+    })
+
+    it('dev can update the emergency value', async () => {
+
+        await priceResolver.connect(admin).setEmergencyPrice(toEther(25));
+        expect(fromEther(await priceResolver.getEmergencyReferencePrice())).to.equal("25.0")
+
+    })
+
+    it('return the correct mint ratio', async () => {
+
+        let rawRatio = await priceResolver.getRawRatio()
+        expect(fromEther(rawRatio)).to.equal("0.5")
+
+        // make it to be reaching the cap
+        await priceFeederCollateral.connect(admin).setAveragePrice(toEther(10));
+        rawRatio = await priceResolver.getRawRatio()
+        expect(fromEther(rawRatio)).to.equal("1.0")
+
+        let currentRatio = await priceResolver.getCurrentRatio()
+        expect(fromEther(currentRatio)).to.equal("0.8")
+
+        expect( await priceResolver.isBullMarket() ).to.true
+
+        // turn the market into bear
+        await priceFeederCollateral.connect(admin).setAveragePrice(toEther(1000));
+        
+        currentRatio = await priceResolver.getCurrentRatio()
+        expect(fromEther(currentRatio)).to.equal("0.2")
+
+        expect( await priceResolver.isBullMarket() ).to.false
+    })
+
+
+})


### PR DESCRIPTION
* Adding a price resolver contract that identify the market is bull or bear
* The contract also calculates the mint ratio which hard-coded a cap of 0.2 and 0.8
* The contract is a proxy to the price feeder contract