### PR TITLE
fix: allow mint synths from exist position

### DIFF
--- a/contractV2/contracts/TokenManager.sol
+++ b/contractV2/contracts/TokenManager.sol
@@ -180,9 +180,9 @@ contract TokenManager is Lockable, Whitelist, ITokenManager {
         uint256 supportCollateral, // stablecoin
         uint256 numTokens // synthetic tokens to be minted
     ) public isReady nonReentrant {
-        require(baseCollateral > 0, "baseCollateral must be greater than 0");
+        require(baseCollateral >= 0, "baseCollateral must be greater than 0");
         require(
-            supportCollateral > 0,
+            supportCollateral >= 0,
             "supportCollateral must be greater than 0"
         );
         require(numTokens > 0, "numTokens must be greater than 0");
@@ -231,17 +231,22 @@ contract TokenManager is Lockable, Whitelist, ITokenManager {
         );
 
         // Transfer tokens into the contract from caller and mint corresponding synthetic tokens to the caller's address.
-        baseCollateralToken.safeTransferFrom(
-            msg.sender,
-            address(this),
-            baseCollateral
-        );
-        supportCollateralToken.safeTransferFrom(
-            msg.sender,
-            address(this),
-            supportCollateral
-        );
-
+        if (baseCollateral > 0) {
+            baseCollateralToken.safeTransferFrom(
+                msg.sender,
+                address(this),
+                baseCollateral
+            );
+        }
+        
+        if (supportCollateral > 0) {
+            supportCollateralToken.safeTransferFrom(
+                msg.sender,
+                address(this),
+                supportCollateral
+            );
+        }
+        
         require(
             syntheticToken.mint(msg.sender, numTokens),
             "Minting synthetic tokens failed"

--- a/contractV2/test/TokenManager.js
+++ b/contractV2/test/TokenManager.js
@@ -181,6 +181,27 @@ describe("TokenManager contract", () => {
         expect(await syntheticToken.balanceOf(alice.address)).to.equal(toEther(0))
     })
 
+    it('mint from existing position and redeem all', async () => {
+
+        let tokenIn = await tokenManager.estimateTokensIn( toEther(1))
+
+        // Mint 1 Synthetic at 300%
+        await tokenManager.connect(alice).mint(toEther(Number(fromEther(tokenIn[0])) * 2.5), toEther(Number(fromEther(tokenIn[1])) * 2.5), toEther(1))
+
+        tokenIn = await tokenManager.estimateTokensIn(toEther(3))
+
+        // Mint another 0.25 Synthetic from existing position
+        await tokenManager.connect(alice).mint(0, 0, toEther(0.25))
+
+        expect(fromEther(await tokenManager.connect(alice).myCollateralizationRatio())).to.equal("2.4")
+        expect(fromEther(await syntheticToken.balanceOf(alice.address))).to.equal("1.25")
+
+        // Redeem All
+        await tokenManager.connect(alice).redeemAll()
+
+        expect(await syntheticToken.balanceOf(alice.address)).to.equal(toEther(0))
+    })
+
 
     it('mint 1 ETH at 300% and redeem 0.5 ETH back', async () => {
 


### PR DESCRIPTION
- Allow mint synthetic tokens from deposit more tokens as long as the collateral ratio still above the liquidation ratio.