### PR TITLE
[Luckbox] Use whitelist per project scheme

### DIFF
--- a/test/NFTLuckbox/LuckBox.js
+++ b/test/NFTLuckbox/LuckBox.js
@@ -20,21 +20,20 @@ describe("LuckBox V2", () => {
 
     const LuckBox = await ethers.getContractFactory("LuckBox")
 
-    luckBox = await LuckBox.deploy()
+    luckBox = await LuckBox.deploy( ethers.constants.AddressZero )
 
     // generate merkle tree of whitelist users (without Dave)
     const leaves = [admin, alice, bob, charlie].map(item => keccak256(item.address))
     treeWL = new MerkleTree(leaves, keccak256 , { sortPairs : true})
-    // create an event
-    const popIds = [1,2,3]
-    await luckBox.createEvent(1, "TEST", popIds)
+    // create a project
+    await luckBox.createProject(1, "TEST")
     // attach WL's root
     const rootWL = treeWL.getHexRoot()
     root = treeWL.getRoot().toString('hex');
-    await luckBox.attachMerkleRootToEvent(1, rootWL , true)
+    await luckBox.attachWhitelist(1, rootWL )
   })
 
-  it("Check eligible users", async () => {
+  it("Check whitelist users for project (1)", async () => {
 
     for (let user of [admin, alice, bob, charlie, dave]) {
 


### PR DESCRIPTION
As per discussion with Theresa, the airdrop facilitator can choose the holder who has specific NFTs in order to participate the airdrop event then the contract must able to receive the proof from the backend per project.
Flow:
- NFT A -> Encrypt all addresses who hold the NFT in the merkle tree then submits the root to the contract -> ROOT A
- NFT B -> ROOT B, NFT C -> ROOT C
- When joining the backend should collects the tree from the DB and then verify with the leaf which is the user address and the root that stored in the contract on-chain 